### PR TITLE
don't give up on symlinks amongst files to install

### DIFF
--- a/bin/...
+++ b/bin/...
@@ -607,7 +607,7 @@ sub _up_to_date {
     my $src = shift;
     my $dst = shift;
     my $method = shift;
-    die "Error: '$src' file does not exist" unless -f $src;
+    die "Error: '$src' file does not exist" unless -e $src;
     return 0 if -s $dst != -s $src;
     if ('symlink' eq $method) {
         return readlink($dst) eq $src


### PR DESCRIPTION
I was trying to install my new vim-dots, and I kept getting complaints that some file didn't exist.  It did, but it was a symlink to a file elsewhere in the repo, rather than a plain file.  This relaxes the check.
