### PR TITLE
don't keep working if "git pull" fails

### DIFF
--- a/bin/...
+++ b/bin/...
@@ -398,7 +398,7 @@ sub _update_one {
             warn "$path exists, but is not a git repo. Ignoring.";
         }
         else {
-            my $pull = 'git pull';
+            my $pull = 'git pull --ff-only';
             my $submods = 'git submodule update --init';
             $class->_run_sys("(cd $path && $pull && $submods)");
             $class->_make(update => $path);


### PR DESCRIPTION
Really, we should not be using `git pull`, because it will want to merge.  We should at least `--ff-only` as done in this commit.

Ideally we would either `git reset` instead, or have an option. Doing a reset, though, is a bit more work because the code will need to know the tracking branch, which I don't offhand know how to get quickly and correctly.  I wanted a lazy solution.

This fix will (a) reject non-ff updates from remote and (b) die, rather than continue, if the pull fails.
