### PR TITLE
handle -p for creating the full dir chain for backups

### DIFF
--- a/bin/...
+++ b/bin/...
@@ -244,7 +244,7 @@ sub do_backup {
         print F "$file\n";
     }
     close F;
-    my $cmd = "(cd $home_dir; mkdir $backup_dir && cat $backup_list_file | cpio -dump $backup_dir)";
+    my $cmd = "(cd $home_dir; mkdir -p $backup_dir && cat $backup_list_file | cpio -dump $backup_dir)";
     $class->_run_sys($cmd);
     print color(32, "Backed up $n dot files to $backup_dir\n");
 }


### PR DESCRIPTION
With the addition of the mkdir in 7fa239f76166e8440d3d5992e96c744e2c42bbeb, the initial ... run will error out if the backup dir doesn't exist. This adds -p to resolve that.