### PR TITLE
remove symlink checks for source

### DIFF
--- a/bin/...
+++ b/bin/...
@@ -613,8 +613,6 @@ sub _up_to_date {
     if ('symlink' eq $method) {
         return readlink($dst) eq $src
     }
-    return $class->_up_to_date($src, $dst, 'symlink') if -l $src;
-    return 0 if -l $src ne -l $dst;
     if ('copy' eq $method) {
         return 0 if _inode_of($src) == _inode_of($dst);
         open S, $src or die;


### PR DESCRIPTION
Was running into issues where if the source file was a symlink, it hit this condition and failed to identify the existing file. I'm not sure what the original intention of these lines was, but they don't seem to serve the intended goal here.

Example consecutive runs before this change:

```
~ bean
❯ rm ~/.weechat/perl/autoload/*
zsh: sure you want to delete all the files in /Users/akerl/.weechat/perl/autoload [yn]? y
~ bean
❯
~ bean
❯ .../... install
Backing up your dot files to /Users/akerl/.../backup/20151130-210758/
> (cd ~; mkdir -p ~/.../backup/20151130-210758 && cat ~/.../tmp/20151130-210758-backup-list | cpio -dump ~/.../backup/20151130-210758)
962 blocks
Backed up 156 dot files to /Users/akerl/.../backup/20151130-210758
Installing your dot files:
> ln ~/.../src/privdotfiles/.weechat/perl/autoload/buffers.pl ~/.weechat/perl/autoload/buffers.pl
> ln ~/.../src/privdotfiles/.weechat/perl/autoload/curiousignore.pl ~/.weechat/perl/autoload/curiousignore.pl
> ln ~/.../src/privdotfiles/.weechat/perl/autoload/iset.pl ~/.weechat/perl/autoload/iset.pl
> ln ~/.../src/privdotfiles/.weechat/python/autoload/allquery.py ~/.weechat/python/autoload/allquery.py
> ln ~/.../src/privdotfiles/.weechat/python/autoload/autojoin.py ~/.weechat/python/autoload/autojoin.py
> ln ~/.../src/privdotfiles/.weechat/python/autoload/buffer_autoset.py ~/.weechat/python/autoload/buffer_autoset.py
> ln ~/.../src/privdotfiles/.weechat/python/autoload/buffer_swap.py ~/.weechat/python/autoload/buffer_swap.py
> ln ~/.../src/privdotfiles/.weechat/python/autoload/shell.py ~/.weechat/python/autoload/shell.py
> ln ~/.../src/privdotfiles/.weechat/python/autoload/whois_in_active_buffer.py ~/.weechat/python/autoload/whois_in_active_buffer.py
> ln ~/.../src/privdotfiles/.weechat/ruby/autoload/pushover.rb ~/.weechat/ruby/autoload/pushover.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/autoload/regex_highlight.rb ~/.weechat/ruby/autoload/regex_highlight.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/autoload/squelch_away.rb ~/.weechat/ruby/autoload/squelch_away.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/autoload/tmux_track.rb ~/.weechat/ruby/autoload/tmux_track.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/pushover.rb ~/.weechat/ruby/pushover.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/regex_highlight.rb ~/.weechat/ruby/regex_highlight.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/squelch_away.rb ~/.weechat/ruby/squelch_away.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/tmux_track.rb ~/.weechat/ruby/tmux_track.rb
159 installed files. (142 skipped | 17 Hardlinked)
~ bean
❯ .../... install
Backing up your dot files to /Users/akerl/.../backup/20151130-210800/
> (cd ~; mkdir -p ~/.../backup/20151130-210800 && cat ~/.../tmp/20151130-210800-backup-list | cpio -dump ~/.../backup/20151130-210800)
962 blocks
Backed up 159 dot files to /Users/akerl/.../backup/20151130-210800
Installing your dot files:
> ln ~/.../src/privdotfiles/.weechat/perl/autoload/buffers.pl ~/.weechat/perl/autoload/buffers.pl
> ln ~/.../src/privdotfiles/.weechat/perl/autoload/curiousignore.pl ~/.weechat/perl/autoload/curiousignore.pl
> ln ~/.../src/privdotfiles/.weechat/perl/autoload/iset.pl ~/.weechat/perl/autoload/iset.pl
> ln ~/.../src/privdotfiles/.weechat/python/autoload/allquery.py ~/.weechat/python/autoload/allquery.py
> ln ~/.../src/privdotfiles/.weechat/python/autoload/autojoin.py ~/.weechat/python/autoload/autojoin.py
> ln ~/.../src/privdotfiles/.weechat/python/autoload/buffer_autoset.py ~/.weechat/python/autoload/buffer_autoset.py
> ln ~/.../src/privdotfiles/.weechat/python/autoload/buffer_swap.py ~/.weechat/python/autoload/buffer_swap.py
> ln ~/.../src/privdotfiles/.weechat/python/autoload/shell.py ~/.weechat/python/autoload/shell.py
> ln ~/.../src/privdotfiles/.weechat/python/autoload/whois_in_active_buffer.py ~/.weechat/python/autoload/whois_in_active_buffer.py
> ln ~/.../src/privdotfiles/.weechat/ruby/autoload/pushover.rb ~/.weechat/ruby/autoload/pushover.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/autoload/regex_highlight.rb ~/.weechat/ruby/autoload/regex_highlight.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/autoload/squelch_away.rb ~/.weechat/ruby/autoload/squelch_away.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/autoload/tmux_track.rb ~/.weechat/ruby/autoload/tmux_track.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/pushover.rb ~/.weechat/ruby/pushover.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/regex_highlight.rb ~/.weechat/ruby/regex_highlight.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/squelch_away.rb ~/.weechat/ruby/squelch_away.rb
> ln ~/.../src/privdotfiles/.weechat/ruby/tmux_track.rb ~/.weechat/ruby/tmux_track.rb
159 installed files. (142 skipped | 17 Hardlinked)
```

Example runs after applying this change:

```
~ bean
❯ rm ~/.weechat/perl/autoload/*
zsh: sure you want to delete all the files in /Users/akerl/.weechat/perl/autoload [yn]? y
~ bean
❯ .../... install
Backing up your dot files to /Users/akerl/.../backup/20151130-211012/
> (cd ~; mkdir -p ~/.../backup/20151130-211012 && cat ~/.../tmp/20151130-211012-backup-list | cpio -dump ~/.../backup/20151130-211012)
962 blocks
Backed up 156 dot files to /Users/akerl/.../backup/20151130-211012
Installing your dot files:
> ln ~/.../src/privdotfiles/.weechat/perl/autoload/buffers.pl ~/.weechat/perl/autoload/buffers.pl
> ln ~/.../src/privdotfiles/.weechat/perl/autoload/curiousignore.pl ~/.weechat/perl/autoload/curiousignore.pl
> ln ~/.../src/privdotfiles/.weechat/perl/autoload/iset.pl ~/.weechat/perl/autoload/iset.pl
159 installed files. (156 skipped | 3 Hardlinked)
~ bean
❯ .../... install
Backing up your dot files to /Users/akerl/.../backup/20151130-211013/
> (cd ~; mkdir -p ~/.../backup/20151130-211013 && cat ~/.../tmp/20151130-211013-backup-list | cpio -dump ~/.../backup/20151130-211013)
962 blocks
Backed up 159 dot files to /Users/akerl/.../backup/20151130-211013
Installing your dot files:
159 installed files. (159 skipped)
```
