### PR TITLE
Allow for force resetting of git repo

### DIFF
--- a/bin/...
+++ b/bin/...
@@ -191,6 +191,12 @@ sub setup {
     die "Error: invalid value for conf setting 'install_method'\n"
         unless $config->{install_method} =~ /^(hardlink|symlink|copy)$/;
 
+    $config->{force} =
+        not(exists($config->{force})) ? 0 :
+        $config->{force} =~ /^(on|true|1)$/ ? 1 :
+        $config->{force} =~ /^(off|false|0)$/ ? 0 :
+        die "Error: invalid value for conf setting 'force'\n";
+
     my ($sec, $min, $hour, $day, $mon, $year) = localtime(time);
     $year += 1900;
     $mon++;
@@ -399,8 +405,11 @@ sub _update_one {
             warn "$path exists, but is not a git repo. Ignoring.";
         }
         else {
+            my $reset = 'git reset --hard HEAD';
+            my $clean = 'git clean -f';
             my $pull = 'git pull --ff-only';
             my $submods = 'git submodule update --init';
+            $class->_run_sys("(cd $path && $clean && $reset)") if $config->{force}; 
             $class->_run_sys("(cd $path && $pull && $submods)");
             $class->_make(update => $path);
         }

--- a/example.conf
+++ b/example.conf
@@ -38,3 +38,9 @@ dots:
 # The default is 'on'.
 
 # auto_backup: on
+
+# To force a git reset and git clean on the src repo before pulling,
+# you can set force: true. This can be used to allow clean installs
+# after hand-testing changes on your live dotfiles
+#
+# force: true


### PR DESCRIPTION
I'll often test a change to a dotfile, then have to cd to ~/.../src/REPO and git checkout before .../... upgrade will cleanly apply. This shortcuts that.
