### PR TITLE
if no files existed, ...eachsource would exit false

### DIFF
--- a/lib/scripting
+++ b/lib/scripting
@@ -75,6 +75,7 @@ function ...@ {
     else
         source ~/.../lib/eachsource.zsh "$@"
     fi
+    true
 }
 
 # By using this you get ...trace abilities, plus it guards against recursion


### PR DESCRIPTION
...and that meant things would fail, like .bashrc, which was
not a great time for anybody